### PR TITLE
fix: improve the stability and reliability of the tests

### DIFF
--- a/src/test/java/hotel/Utils.java
+++ b/src/test/java/hotel/Utils.java
@@ -12,8 +12,7 @@ import org.openqa.selenium.chrome.ChromeOptions;
 
 public class Utils {
 
-  public static final String BASE_URL = Objects.requireNonNullElse(System.getenv("BASE_URL"),
-      "https://hotel-example-site.takeyaqa.dev/en-US");
+  public static final String BASE_URL = Objects.requireNonNullElse(System.getenv("BASE_URL"), "https://hotel-example-site.takeyaqa.dev/en-US");
 
   private Utils() {
     throw new AssertionError();
@@ -23,15 +22,7 @@ public class Utils {
     var githubActions = Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"));
     var remoteContainers = Boolean.parseBoolean(System.getenv("REMOTE_CONTAINERS"));
     var codespaces = Boolean.parseBoolean(System.getenv("CODESPACES"));
-
-    // Disable password manager popup
-    Map<String, Object> chromePrefs = new HashMap<>();
-    chromePrefs.put("credentials_enable_service", false);
-    chromePrefs.put("profile.password_manager_enabled", false);
-    chromePrefs.put("profile.password_manager_leak_detection", false);
-
     var options = new ChromeOptions();
-    options.setExperimentalOption("prefs", chromePrefs);
     if (githubActions) {
       options.addArguments("--headless");
     } else if (remoteContainers || codespaces) {

--- a/src/test/java/hotel/Utils.java
+++ b/src/test/java/hotel/Utils.java
@@ -2,6 +2,8 @@ package hotel;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;
@@ -10,7 +12,8 @@ import org.openqa.selenium.chrome.ChromeOptions;
 
 public class Utils {
 
-  public static final String BASE_URL = Objects.requireNonNullElse(System.getenv("BASE_URL"), "https://hotel-example-site.takeyaqa.dev/en-US");
+  public static final String BASE_URL = Objects.requireNonNullElse(System.getenv("BASE_URL"),
+      "https://hotel-example-site.takeyaqa.dev/en-US");
 
   private Utils() {
     throw new AssertionError();
@@ -20,7 +23,15 @@ public class Utils {
     var githubActions = Boolean.parseBoolean(System.getenv("GITHUB_ACTIONS"));
     var remoteContainers = Boolean.parseBoolean(System.getenv("REMOTE_CONTAINERS"));
     var codespaces = Boolean.parseBoolean(System.getenv("CODESPACES"));
+
+    // Disable password manager popup
+    Map<String, Object> chromePrefs = new HashMap<>();
+    chromePrefs.put("credentials_enable_service", false);
+    chromePrefs.put("profile.password_manager_enabled", false);
+    chromePrefs.put("profile.password_manager_leak_detection", false);
+
     var options = new ChromeOptions();
+    options.setExperimentalOption("prefs", chromePrefs);
     if (githubActions) {
       options.addArguments("--headless");
     } else if (remoteContainers || codespaces) {

--- a/src/test/java/hotel/Utils.java
+++ b/src/test/java/hotel/Utils.java
@@ -2,8 +2,6 @@ package hotel;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.WebDriver;

--- a/src/test/java/hotel/pages/ConfirmPage.java
+++ b/src/test/java/hotel/pages/ConfirmPage.java
@@ -18,6 +18,7 @@ public class ConfirmPage {
   public ConfirmPage(WebDriver driver) {
     this.driver = driver;
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("Confirm Reservation"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("Confirm Reservation")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/IconPage.java
+++ b/src/test/java/hotel/pages/IconPage.java
@@ -1,17 +1,25 @@
 package hotel.pages;
 
 import java.nio.file.Path;
+import java.time.Duration;
+
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.Color;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class IconPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public IconPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("Setting Icon"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("Setting Icon")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/IconPage.java
+++ b/src/test/java/hotel/pages/IconPage.java
@@ -2,7 +2,6 @@ package hotel.pages;
 
 import java.nio.file.Path;
 import java.time.Duration;
-
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;

--- a/src/test/java/hotel/pages/LoginPage.java
+++ b/src/test/java/hotel/pages/LoginPage.java
@@ -2,13 +2,21 @@ package hotel.pages;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
 
 public class LoginPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public LoginPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("Login"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("Login")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/LoginPage.java
+++ b/src/test/java/hotel/pages/LoginPage.java
@@ -1,11 +1,10 @@
 package hotel.pages;
 
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-
-import java.time.Duration;
 
 public class LoginPage {
 

--- a/src/test/java/hotel/pages/MyPage.java
+++ b/src/test/java/hotel/pages/MyPage.java
@@ -1,15 +1,22 @@
 package hotel.pages;
 
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.Color;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class MyPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public MyPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("MyPage"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("MyPage")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/PlansPage.java
+++ b/src/test/java/hotel/pages/PlansPage.java
@@ -18,6 +18,7 @@ public class PlansPage {
   public PlansPage(WebDriver driver) {
     this.driver = driver;
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("Plans"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("Plans")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/ReservePage.java
+++ b/src/test/java/hotel/pages/ReservePage.java
@@ -31,6 +31,7 @@ public class ReservePage {
   public ReservePage(WebDriver driver) {
     this.driver = driver;
     this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("Reservation"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("Reservation")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/SignupPage.java
+++ b/src/test/java/hotel/pages/SignupPage.java
@@ -1,10 +1,13 @@
 package hotel.pages;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.Select;
+import org.openqa.selenium.support.ui.WebDriverWait;
 
 public class SignupPage {
 
@@ -26,8 +29,12 @@ public class SignupPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public SignupPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleContains("Sign up"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().startsWith("Sign up")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }

--- a/src/test/java/hotel/pages/TopPage.java
+++ b/src/test/java/hotel/pages/TopPage.java
@@ -1,11 +1,10 @@
 package hotel.pages;
 
+import java.time.Duration;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
-
-import java.time.Duration;
 
 public class TopPage {
 

--- a/src/test/java/hotel/pages/TopPage.java
+++ b/src/test/java/hotel/pages/TopPage.java
@@ -2,13 +2,21 @@ package hotel.pages;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import org.openqa.selenium.support.ui.WebDriverWait;
+
+import java.time.Duration;
 
 public class TopPage {
 
   private final WebDriver driver;
 
+  private final WebDriverWait wait;
+
   public TopPage(WebDriver driver) {
     this.driver = driver;
+    this.wait = new WebDriverWait(driver, Duration.ofSeconds(10));
+    this.wait.until(ExpectedConditions.titleIs("HOTEL PLANISPHERE - Website for Practice Test Automation"));
     if (this.driver.getTitle() == null || !this.driver.getTitle().equals("HOTEL PLANISPHERE - Website for Practice Test Automation")) {
       throw new IllegalStateException("wrong page: " + this.driver.getTitle());
     }


### PR DESCRIPTION
This pull request includes changes to multiple test page classes in the `hotel.pages` package to improve the stability and reliability of the tests by adding explicit waits for specific page titles.

Improvements to test stability:

* [`src/test/java/hotel/pages/ConfirmPage.java`](diffhunk://#diff-bcb5a542ffa023cf311c634df08ff92ac22a15747c8f321a119d14ab9f02c4c3R21): Added an explicit wait for the "Confirm Reservation" title to ensure the page is fully loaded before proceeding with tests.
* [`src/test/java/hotel/pages/IconPage.java`](diffhunk://#diff-0d85b8c8ad56d9e0ee84fb5a540a800e7da3fc28574ac643aee32983bbbc00baR4-R21): Introduced a `WebDriverWait` to wait for the "Setting Icon" title, ensuring the page is ready for interaction.
* [`src/test/java/hotel/pages/LoginPage.java`](diffhunk://#diff-e72d597a90cfda555d11e535016d2564d88e8ee4318c4f995cdaf60caa218086R3-R18): Implemented a wait for the "Login" title to improve test reliability by confirming the page load.
* [`src/test/java/hotel/pages/PlansPage.java`](diffhunk://#diff-8c5905455b3894318a579cafff054096b7f833922c01c4dadbe9df221d9df621R21): Added a wait for the "Plans" title to ensure the page is fully loaded before executing tests.
* [`src/test/java/hotel/pages/SignupPage.java`](diffhunk://#diff-a3235738734e2450b79f78441bfb10eac77392ae15b29c925cde90a5e6677612R3-R10): Included a `WebDriverWait` to wait for the "Sign up" title, ensuring the page is ready for test interactions. [[1]](diffhunk://#diff-a3235738734e2450b79f78441bfb10eac77392ae15b29c925cde90a5e6677612R3-R10) [[2]](diffhunk://#diff-a3235738734e2450b79f78441bfb10eac77392ae15b29c925cde90a5e6677612R32-R37)