### PR TITLE
docs: remove repository migration notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,6 @@
 
 [![selenium4-java-en-us](https://github.com/takeyaqa/hotel-example-selenium4-java-en-us/actions/workflows/test.yml/badge.svg)](https://github.com/takeyaqa/hotel-example-selenium4-java-en-us/actions/workflows/test.yml)
 
----
-
-## Repository Migration Notice
-
-> [!IMPORTANT]
-> This repository has been migrated to personal ownership. Previously managed under [Test Planisphere](https://github.com/testplanisphere), it is now maintained by [@takeyaqa](https://github.com/takeyaqa).
->
-> The new repository URL is:
->
-> [https://github.com/takeyaqa/hotel-example-selenium4-java-en-us](https://github.com/takeyaqa/hotel-example-selenium4-java-en-us)
->
-> This migration does not affect the content or purpose of the repository. However, if you have cloned or forked this repository, you may need to update your remote URL.
-
----
-
 This project is example codes for learning test automation.
 
 ### System under test


### PR DESCRIPTION
This pull request removes outdated migration information from the `README.md` file, simplifying the documentation and ensuring it focuses solely on the project's purpose and usage.

Documentation cleanup:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-L19): Removed the "Repository Migration Notice" section, which included details about the migration of the repository to personal ownership. This section is no longer relevant and was removed to streamline the documentation.