### PR TITLE
ci: remove matrix strategy and BASE_URL environment variable from test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,6 @@ on:
 
 jobs:
   test:
-    strategy:
-      matrix:
-        base-url: ["https://hotel-example-site.takeyaqa.dev/en-US", "https://hotel.testplanisphere.dev/en-US"]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -22,5 +19,3 @@ jobs:
       uses: gradle/actions/setup-gradle@v4
     - name: Build with Gradle Wrapper
       run: ./gradlew test
-      env:
-        BASE_URL: ${{ matrix.base-url }}


### PR DESCRIPTION
This pull request includes changes to simplify the workflow configuration in `.github/workflows/test.yml`. The matrix strategy for testing multiple base URLs has been removed, along with the associated environment variable setup.

Workflow simplification:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-L12): Removed the matrix strategy for testing multiple base URLs under the `test` job.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L25-L26): Removed the `BASE_URL` environment variable setup in the Gradle build step.